### PR TITLE
Clarify example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,23 @@ An extensible class to define hyperHTML based Custom Elements.
 ### The Class
 ```js
 const HyperHTMLElement = require('hyperhtml-element');
+const hyperHTML = require('hyperhtml');
 
 class MyElement extends HyperHTMLElement {
+  constructor() {
+    // create a shadow root
+    const shadow = this.attachShadow({mode: 'open'});
+
+    // this.html property points to an hyperHTML bound context
+    // which could be either the element shadowRoot or the element itself.
+    this.html = hyperHTML.bind(shadow);
+  }
   // observed attributes are automatically defined as accessors
   static get observedAttributes() { return ['key']; }
 
   // invoked once the component has been fully upgraded
   // suitable to perform any sort of setup
-  // granted to be invoked right before either
+  // guaranteed to be invoked right before either
   // connectedCallback or attributeChangedCallback
   created() {
     // triggers automatically attributeChangedCallback
@@ -32,11 +41,10 @@ class MyElement extends HyperHTMLElement {
   }
 
   render() {
-    // lazily defined, this.html property points to an hyperHTML bound context
-    // which could be the element shadowRoot or the element itself.
-    // All events can be handled directly by the context, thanks to handleEvent
+    // Using explicit event handler here.
+    // Events may also be delegated to the context by using handleEvent. See:
     // https://medium.com/@WebReflection/dom-handleevent-a-cross-platform-standard-since-year-2000-5bf17287fd38
-    return this.html`Hello <strong onclick="${this}">HyperHTMLElement</strong>`;
+    return this.html`Hello <strong onclick="${this.onclick}">HyperHTMLElement</strong>`;
   }
 
   // using the inherited handleEvent,


### PR DESCRIPTION
First, thanks for working on these ideas! I'm following along with interest and starting to use them in personal projects.

Following along with the docs isn't always easy. This is more of a problem when ready-to-go examples are incomplete.

This PR clarifies the example for a class extending HyperElement:

- explicitly require `hyperHTML` to make it clear it's required

- define `this.html` bound to a `shadowRoot`, a common use case for Custom Elements.
This particular one bit me hard. The comment in `render()` wasn't clear that this method MUST be defined. Added it in the constructor to help others after me.

- explicitly call `this.onclick` event handler. 
I like your idea with `handleEvent`, but it wasn't written anywhere in the code here and it WILL trip up people unfamiliar with the delegation mechanism.

Good job on the libraries so far!
The docs need improving and better structure. 
I'd like to help here and there where I can.