### PR TITLE
Fixed Browsers which support Symbol.hasInstance

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -195,6 +195,7 @@ class HyperHTMLElement extends HTMLElement {
       classes.push(Class);
       customElements.define(name, Class, options);
     } else {
+      classes.push(Class);
       customElements.define(name, Class);
     }
     return Class;


### PR DESCRIPTION
https://webreflection.github.io/hyperHTML-Element/test/?es5 - was broken in Chrome and Firefox in 1.8 version 