### PR TITLE
Add the handleEvent method to the HyperHTMLElement types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ declare class HyperHTMLElement<T = {}> {
    constructor();
    created(): void;
    attributeChangedCallback(name: string, prev: string, curr: string): void;
+   handleEvent(ev: Event): void;
    html: WiredTemplateFunction;
    state: T;
    readonly defaultState: T;


### PR DESCRIPTION
This will allow typescript to use the HyperHTMLElement instance as an EventListenerObject