### PR TITLE
feat: Add `html` alias for `hyper`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2170,6 +2170,7 @@ var HyperHTMLElement = (function (exports) {
   hyper.define = define;
   hyper.diff = domdiff;
   hyper.hyper = hyper;
+  hyper.html = hyper;
   hyper.observe = observe;
   hyper.tagger = tagger;
   hyper.wire = wire;


### PR DESCRIPTION
IDEs like Atom can syntax highlight `html` blocks (also semantically clear that may behave similarly to `this.html`)