### PR TITLE
Update TypeScript definition of 'get defaultState'.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -78,7 +78,7 @@ declare class HyperHTMLElement<T = {}> {
    handleEvent(ev: Event): void;
    html: WiredTemplateFunction;
    state: T;
-   readonly defaultState: T;
+   get defaultState(): T;
    render(): void;
    setState(state: Partial<T> | ((this: this, state: T) => Partial<T>)): void;
    static bind: typeof bind;


### PR DESCRIPTION
Now it's impossible to define getter for 'defaultState' with TypeScript.
Following error appears:
"'defaultState' is defined as a property in class 'HyperHTMLElement<{}>', but is overridden here in 'MyComponent' as an accessor."
See full description in issue: https://github.com/WebReflection/hyperHTML-Element/issues/77

This is because defaultState is defined as just readonly property
when it should be described as getter.
Description for 'defaultState' was updated to define it as 'getter'